### PR TITLE
Find gunrock lib without changing source code

### DIFF
--- a/src/Gunrock.jl
+++ b/src/Gunrock.jl
@@ -1,5 +1,5 @@
 module Gunrock
-	include("consts.jl")
+    include("config.jl")
 	include("bfs.jl")
 	include("cc.jl")
 	include("sssp.jl")

--- a/src/bc.jl
+++ b/src/bc.jl
@@ -19,6 +19,6 @@ function bc(G::SparseMatrixCSC, root::Int)
     rows = map(Int32, rows)
     cols = map(Int32, cols)
     bc_scores = Array(Cfloat, nodes)
-	ccall((:bc, path_to_gunrock), Void, (Ptr{Cfloat}, Int, Int, Ptr{Cint}, Ptr{Cint}, Int), bc_scores, nodes, edges, rows, cols, root - 1)
+	ccall((:bc, gunrock_lib), Void, (Ptr{Cfloat}, Int, Int, Ptr{Cint}, Ptr{Cint}, Int), bc_scores, nodes, edges, rows, cols, root - 1)
 	bc_scores
 end

--- a/src/bfs.jl
+++ b/src/bfs.jl
@@ -19,7 +19,7 @@ function bfs(G::SparseMatrixCSC, root::Int)
     rows = map(Int32, rows)
     cols = map(Int32, cols)
     bfs_label = Array(Int32, nodes)
-	ccall((:bfs, path_to_gunrock), Void, (Ptr{Cint}, Int, Int, Ptr{Cint}, Ptr{Cint}, Int), bfs_label, nodes, edges, rows, cols, root - 1)
+	ccall((:bfs, gunrock_lib), Void, (Ptr{Cint}, Int, Int, Ptr{Cint}, Ptr{Cint}, Int), bfs_label, nodes, edges, rows, cols, root - 1)
     bfs_label += 1
 	bfs_label
 end

--- a/src/cc.jl
+++ b/src/cc.jl
@@ -19,7 +19,7 @@ function cc(G::SparseMatrixCSC)
     rows = map(Int32, rows)
     cols = map(Int32, cols)
     conn_comp = Array(Int32, nodes)
-	num_cc = ccall((:cc, path_to_gunrock), Cint, (Ptr{Cint}, Int, Int, Ptr{Cint}, Ptr{Cint}), conn_comp, nodes, edges, rows, cols)
+	num_cc = ccall((:cc, gunrock_lib), Cint, (Ptr{Cint}, Int, Int, Ptr{Cint}, Ptr{Cint}), conn_comp, nodes, edges, rows, cols)
     conn_comp += 1
 	num_cc, conn_comp
 end

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,0 +1,13 @@
+#Set Gunrock path
+let
+    global gunrock_lib
+    succeeded = false
+    if !isdefined(:gunrock_lib)
+        @linux_only lib = "libgunrock.so"
+        Libdl.dlopen(lib)
+        succeeded = true
+        succeeded || error("Gunrock library not found")
+        @eval const gunrock_lib = $lib
+    end
+end
+        

--- a/src/consts.jl
+++ b/src/consts.jl
@@ -1,2 +1,0 @@
-#const path_to_gunrock = 
-const path_to_gunrock = "/home/ubuntu/gunrock/build/lib/libgunrock.so"

--- a/src/pagerank.jl
+++ b/src/pagerank.jl
@@ -20,7 +20,7 @@ function pagerank(G::SparseMatrixCSC)
     cols = map(Int32, cols)
     top_nodes = Array(Int32, nodes)
     top_ranks = Array(Cfloat, nodes)
-	ccall((:pagerank, path_to_gunrock), Void, (Ptr{Cint}, Ptr{Cfloat}, Int, Int, Ptr{Cint}, Ptr{Cint}), top_nodes, top_ranks, nodes, edges, rows, cols)
+	ccall((:pagerank, gunrock_lib), Void, (Ptr{Cint}, Ptr{Cfloat}, Int, Int, Ptr{Cint}, Ptr{Cint}), top_nodes, top_ranks, nodes, edges, rows, cols)
     top_nodes += 1
 	top_nodes, top_ranks
 end

--- a/src/sssp.jl
+++ b/src/sssp.jl
@@ -20,6 +20,6 @@ function sssp(G::SparseMatrixCSC, root::Int)
     cols = map(Int32, cols)
 	vals = ones(Cint, edges)
     sssp_dist = Array(Cuint, nodes)
-	ccall((:sssp, path_to_gunrock), Void, (Ptr{Cuint}, Int, Int, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Int), sssp_dist, nodes, edges, rows, cols, vals, root - 1)
+	ccall((:sssp, gunrock_lib), Void, (Ptr{Cuint}, Int, Int, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Int), sssp_dist, nodes, edges, rows, cols, vals, root - 1)
 	sssp_dist
 end


### PR DESCRIPTION
This fix removes the need for users to set `path_to_gunrock` in `consts.jl`. Instead, the user must add the location to `libgunrock.so` to `LD_LIBRARY_PATH`. 
